### PR TITLE
Port subscribe

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   resolver: './jest.resolver.js',
   testRegex: '/src/.+\\.test\\.ts$',
   watchPathIgnorePatterns: ['/src/fixtures/.*$'],
+  testTimeout: 10_000,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6278,6 +6278,12 @@
         "makeerror": "1.0.x"
       }
     },
+    "web-streams-polyfill": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz",
+      "integrity": "sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg==",
+      "dev": true
+    },
     "webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@types/jest": "^25.2.3",
+    "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",
     "eslint": "^7.1.0",
@@ -22,7 +23,7 @@
     "ts-jest": "^26.0.0",
     "typedoc": "^0.17.7",
     "typescript": "^3.9.3",
-    "@types/node-fetch": "^2.5.7"
+    "web-streams-polyfill": "^2.1.1"
   },
   "module": "out/mod.js",
   "main": "out.cjs/mod.js"

--- a/src/fixtures/conflicting commits.json
+++ b/src/fixtures/conflicting commits.json
@@ -7,6 +7,17 @@
   },
   {
     "dbName": "conflict",
+    "method": "openTransaction",
+    "args": {
+      "args": "a",
+      "name": "mutA"
+    },
+    "result": {
+      "transactionId": 1
+    }
+  },
+  {
+    "dbName": "conflict",
     "method": "getRoot",
     "args": {},
     "result": {
@@ -21,17 +32,6 @@
       "name": "mutB"
     },
     "result": {
-      "transactionId": 1
-    }
-  },
-  {
-    "dbName": "conflict",
-    "method": "openTransaction",
-    "args": {
-      "args": "a",
-      "name": "mutA"
-    },
-    "result": {
       "transactionId": 2
     }
   },
@@ -39,7 +39,7 @@
     "dbName": "conflict",
     "method": "put",
     "args": {
-      "transactionId": 2,
+      "transactionId": 1,
       "key": "k",
       "value": "a"
     },
@@ -49,7 +49,7 @@
     "dbName": "conflict",
     "method": "put",
     "args": {
-      "transactionId": 1,
+      "transactionId": 2,
       "key": "k",
       "value": "b"
     },
@@ -59,7 +59,7 @@
     "dbName": "conflict",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 2
+      "transactionId": 1
     },
     "result": {
       "ref": "kb6k8lppbdsh6lpvudngtllh7p3h3eql"
@@ -75,9 +75,25 @@
   },
   {
     "dbName": "conflict",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 3
+    },
+    "result": {}
+  },
+  {
+    "dbName": "conflict",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 4
+    }
+  },
+  {
+    "dbName": "conflict",
     "method": "get",
     "args": {
-      "transactionId": 3,
+      "transactionId": 4,
       "key": "k"
     },
     "result": {
@@ -89,7 +105,7 @@
     "dbName": "conflict",
     "method": "closeTransaction",
     "args": {
-      "transactionId": 3
+      "transactionId": 4
     },
     "result": {}
   },
@@ -97,7 +113,7 @@
     "dbName": "conflict",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 1
+      "transactionId": 2
     },
     "result": {
       "retryCommit": true
@@ -111,14 +127,14 @@
       "name": "mutB"
     },
     "result": {
-      "transactionId": 4
+      "transactionId": 5
     }
   },
   {
     "dbName": "conflict",
     "method": "put",
     "args": {
-      "transactionId": 4,
+      "transactionId": 5,
       "key": "k",
       "value": "b"
     },
@@ -128,7 +144,7 @@
     "dbName": "conflict",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 4
+      "transactionId": 5
     },
     "result": {
       "ref": "m3323carbgqml43e2h54gq06kpbn5340"
@@ -139,14 +155,30 @@
     "method": "openTransaction",
     "args": {},
     "result": {
-      "transactionId": 5
+      "transactionId": 6
     }
+  },
+  {
+    "dbName": "conflict",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 7
+    }
+  },
+  {
+    "dbName": "conflict",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 6
+    },
+    "result": {}
   },
   {
     "dbName": "conflict",
     "method": "get",
     "args": {
-      "transactionId": 5,
+      "transactionId": 7,
       "key": "k"
     },
     "result": {
@@ -158,7 +190,7 @@
     "dbName": "conflict",
     "method": "closeTransaction",
     "args": {
-      "transactionId": 5
+      "transactionId": 7
     },
     "result": {}
   },

--- a/src/fixtures/name.json
+++ b/src/fixtures/name.json
@@ -20,6 +20,14 @@
     "result": ""
   },
   {
+    "dbName": "b",
+    "method": "getRoot",
+    "args": {},
+    "result": {
+      "root": "e99uif9c7bpavajrt666es1ki52dv239"
+    }
+  },
+  {
     "dbName": "a",
     "method": "openTransaction",
     "args": {
@@ -30,14 +38,6 @@
     },
     "result": {
       "transactionId": 1
-    }
-  },
-  {
-    "dbName": "b",
-    "method": "getRoot",
-    "args": {},
-    "result": {
-      "root": "e99uif9c7bpavajrt666es1ki52dv239"
     }
   },
   {
@@ -59,6 +59,22 @@
     "result": {
       "ref": "idi79kd5godt1q480k7joofcs0483aua"
     }
+  },
+  {
+    "dbName": "a",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 2
+    }
+  },
+  {
+    "dbName": "a",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 2
+    },
+    "result": {}
   },
   {
     "dbName": "b",
@@ -94,7 +110,7 @@
     }
   },
   {
-    "dbName": "a",
+    "dbName": "b",
     "method": "openTransaction",
     "args": {},
     "result": {
@@ -103,9 +119,25 @@
   },
   {
     "dbName": "a",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 3
+    }
+  },
+  {
+    "dbName": "b",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 2
+    },
+    "result": {}
+  },
+  {
+    "dbName": "a",
     "method": "get",
     "args": {
-      "transactionId": 2,
+      "transactionId": 3,
       "key": "key"
     },
     "result": {
@@ -117,7 +149,7 @@
     "dbName": "a",
     "method": "closeTransaction",
     "args": {
-      "transactionId": 2
+      "transactionId": 3
     },
     "result": {}
   },
@@ -126,14 +158,14 @@
     "method": "openTransaction",
     "args": {},
     "result": {
-      "transactionId": 2
+      "transactionId": 3
     }
   },
   {
     "dbName": "b",
     "method": "get",
     "args": {
-      "transactionId": 2,
+      "transactionId": 3,
       "key": "key"
     },
     "result": {
@@ -142,18 +174,18 @@
     }
   },
   {
-    "dbName": "b",
-    "method": "closeTransaction",
-    "args": {
-      "transactionId": 2
-    },
-    "result": {}
-  },
-  {
     "dbName": "a",
     "method": "close",
     "args": {},
     "result": ""
+  },
+  {
+    "dbName": "b",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 3
+    },
+    "result": {}
   },
   {
     "dbName": "b",

--- a/src/fixtures/put, get, has, del inside tx.json
+++ b/src/fixtures/put, get, has, del inside tx.json
@@ -95,6 +95,22 @@
   {
     "dbName": "test3",
     "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 2
+    }
+  },
+  {
+    "dbName": "test3",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 2
+    },
+    "result": {}
+  },
+  {
+    "dbName": "test3",
+    "method": "openTransaction",
     "args": {
       "args": {
         "key": "b",
@@ -103,14 +119,14 @@
       "name": "mut"
     },
     "result": {
-      "transactionId": 2
+      "transactionId": 3
     }
   },
   {
     "dbName": "test3",
     "method": "put",
     "args": {
-      "transactionId": 2,
+      "transactionId": 3,
       "key": "b",
       "value": false
     },
@@ -120,7 +136,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 2,
+      "transactionId": 3,
       "key": "b"
     },
     "result": {
@@ -131,7 +147,7 @@
     "dbName": "test3",
     "method": "get",
     "args": {
-      "transactionId": 2,
+      "transactionId": 3,
       "key": "b"
     },
     "result": {
@@ -143,7 +159,7 @@
     "dbName": "test3",
     "method": "del",
     "args": {
-      "transactionId": 2,
+      "transactionId": 3,
       "key": "b"
     },
     "result": {
@@ -154,7 +170,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 2,
+      "transactionId": 3,
       "key": "b"
     },
     "result": {
@@ -165,11 +181,27 @@
     "dbName": "test3",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 2
+      "transactionId": 3
     },
     "result": {
       "ref": "cac8csk9rcfec1o3mlc0t7cfm3ivomj0"
     }
+  },
+  {
+    "dbName": "test3",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 4
+    }
+  },
+  {
+    "dbName": "test3",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 4
+    },
+    "result": {}
   },
   {
     "dbName": "test3",
@@ -182,14 +214,14 @@
       "name": "mut"
     },
     "result": {
-      "transactionId": 3
+      "transactionId": 5
     }
   },
   {
     "dbName": "test3",
     "method": "put",
     "args": {
-      "transactionId": 3,
+      "transactionId": 5,
       "key": "c",
       "value": null
     },
@@ -199,7 +231,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 3,
+      "transactionId": 5,
       "key": "c"
     },
     "result": {
@@ -210,7 +242,7 @@
     "dbName": "test3",
     "method": "get",
     "args": {
-      "transactionId": 3,
+      "transactionId": 5,
       "key": "c"
     },
     "result": {
@@ -222,7 +254,7 @@
     "dbName": "test3",
     "method": "del",
     "args": {
-      "transactionId": 3,
+      "transactionId": 5,
       "key": "c"
     },
     "result": {
@@ -233,7 +265,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 3,
+      "transactionId": 5,
       "key": "c"
     },
     "result": {
@@ -244,10 +276,18 @@
     "dbName": "test3",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 3
+      "transactionId": 5
     },
     "result": {
       "ref": "8ldvv83o1nrshp23mg4754nem4ec49gn"
+    }
+  },
+  {
+    "dbName": "test3",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 6
     }
   },
   {
@@ -261,14 +301,22 @@
       "name": "mut"
     },
     "result": {
-      "transactionId": 4
+      "transactionId": 7
     }
+  },
+  {
+    "dbName": "test3",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 6
+    },
+    "result": {}
   },
   {
     "dbName": "test3",
     "method": "put",
     "args": {
-      "transactionId": 4,
+      "transactionId": 7,
       "key": "d",
       "value": "string"
     },
@@ -278,7 +326,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 4,
+      "transactionId": 7,
       "key": "d"
     },
     "result": {
@@ -289,7 +337,7 @@
     "dbName": "test3",
     "method": "get",
     "args": {
-      "transactionId": 4,
+      "transactionId": 7,
       "key": "d"
     },
     "result": {
@@ -301,7 +349,7 @@
     "dbName": "test3",
     "method": "del",
     "args": {
-      "transactionId": 4,
+      "transactionId": 7,
       "key": "d"
     },
     "result": {
@@ -312,7 +360,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 4,
+      "transactionId": 7,
       "key": "d"
     },
     "result": {
@@ -323,11 +371,27 @@
     "dbName": "test3",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 4
+      "transactionId": 7
     },
     "result": {
       "ref": "vrf6l81rjjo80ejehtlkkr98iq6d2gbs"
     }
+  },
+  {
+    "dbName": "test3",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 8
+    }
+  },
+  {
+    "dbName": "test3",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 8
+    },
+    "result": {}
   },
   {
     "dbName": "test3",
@@ -340,14 +404,14 @@
       "name": "mut"
     },
     "result": {
-      "transactionId": 5
+      "transactionId": 9
     }
   },
   {
     "dbName": "test3",
     "method": "put",
     "args": {
-      "transactionId": 5,
+      "transactionId": 9,
       "key": "e",
       "value": 12
     },
@@ -357,7 +421,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 5,
+      "transactionId": 9,
       "key": "e"
     },
     "result": {
@@ -368,7 +432,7 @@
     "dbName": "test3",
     "method": "get",
     "args": {
-      "transactionId": 5,
+      "transactionId": 9,
       "key": "e"
     },
     "result": {
@@ -380,7 +444,7 @@
     "dbName": "test3",
     "method": "del",
     "args": {
-      "transactionId": 5,
+      "transactionId": 9,
       "key": "e"
     },
     "result": {
@@ -391,7 +455,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 5,
+      "transactionId": 9,
       "key": "e"
     },
     "result": {
@@ -402,10 +466,18 @@
     "dbName": "test3",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 5
+      "transactionId": 9
     },
     "result": {
       "ref": "dtv73vb7hf8m1oimhfvqhqsasbsn82d4"
+    }
+  },
+  {
+    "dbName": "test3",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 10
     }
   },
   {
@@ -419,14 +491,22 @@
       "name": "mut"
     },
     "result": {
-      "transactionId": 6
+      "transactionId": 11
     }
+  },
+  {
+    "dbName": "test3",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 10
+    },
+    "result": {}
   },
   {
     "dbName": "test3",
     "method": "put",
     "args": {
-      "transactionId": 6,
+      "transactionId": 11,
       "key": "f",
       "value": {}
     },
@@ -436,7 +516,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 6,
+      "transactionId": 11,
       "key": "f"
     },
     "result": {
@@ -447,7 +527,7 @@
     "dbName": "test3",
     "method": "get",
     "args": {
-      "transactionId": 6,
+      "transactionId": 11,
       "key": "f"
     },
     "result": {
@@ -459,7 +539,7 @@
     "dbName": "test3",
     "method": "del",
     "args": {
-      "transactionId": 6,
+      "transactionId": 11,
       "key": "f"
     },
     "result": {
@@ -470,7 +550,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 6,
+      "transactionId": 11,
       "key": "f"
     },
     "result": {
@@ -481,11 +561,27 @@
     "dbName": "test3",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 6
+      "transactionId": 11
     },
     "result": {
       "ref": "rpr4rlbv7ppes9165tfs5ogdaqi6ap5i"
     }
+  },
+  {
+    "dbName": "test3",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 12
+    }
+  },
+  {
+    "dbName": "test3",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 12
+    },
+    "result": {}
   },
   {
     "dbName": "test3",
@@ -498,14 +594,14 @@
       "name": "mut"
     },
     "result": {
-      "transactionId": 7
+      "transactionId": 13
     }
   },
   {
     "dbName": "test3",
     "method": "put",
     "args": {
-      "transactionId": 7,
+      "transactionId": 13,
       "key": "g",
       "value": []
     },
@@ -515,7 +611,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 7,
+      "transactionId": 13,
       "key": "g"
     },
     "result": {
@@ -526,7 +622,7 @@
     "dbName": "test3",
     "method": "get",
     "args": {
-      "transactionId": 7,
+      "transactionId": 13,
       "key": "g"
     },
     "result": {
@@ -538,7 +634,7 @@
     "dbName": "test3",
     "method": "del",
     "args": {
-      "transactionId": 7,
+      "transactionId": 13,
       "key": "g"
     },
     "result": {
@@ -549,7 +645,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 7,
+      "transactionId": 13,
       "key": "g"
     },
     "result": {
@@ -560,10 +656,18 @@
     "dbName": "test3",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 7
+      "transactionId": 13
     },
     "result": {
       "ref": "stuvecgd024s7ktrcn405327t5shf16e"
+    }
+  },
+  {
+    "dbName": "test3",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 14
     }
   },
   {
@@ -579,14 +683,22 @@
       "name": "mut"
     },
     "result": {
-      "transactionId": 8
+      "transactionId": 15
     }
+  },
+  {
+    "dbName": "test3",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 14
+    },
+    "result": {}
   },
   {
     "dbName": "test3",
     "method": "put",
     "args": {
-      "transactionId": 8,
+      "transactionId": 15,
       "key": "h",
       "value": {
         "h1": true
@@ -598,7 +710,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 8,
+      "transactionId": 15,
       "key": "h"
     },
     "result": {
@@ -609,7 +721,7 @@
     "dbName": "test3",
     "method": "get",
     "args": {
-      "transactionId": 8,
+      "transactionId": 15,
       "key": "h"
     },
     "result": {
@@ -623,7 +735,7 @@
     "dbName": "test3",
     "method": "del",
     "args": {
-      "transactionId": 8,
+      "transactionId": 15,
       "key": "h"
     },
     "result": {
@@ -634,7 +746,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 8,
+      "transactionId": 15,
       "key": "h"
     },
     "result": {
@@ -645,10 +757,18 @@
     "dbName": "test3",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 8
+      "transactionId": 15
     },
     "result": {
       "ref": "57shmf9caa15v6slgjs07lcfdiavuesk"
+    }
+  },
+  {
+    "dbName": "test3",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 16
     }
   },
   {
@@ -665,14 +785,22 @@
       "name": "mut"
     },
     "result": {
-      "transactionId": 9
+      "transactionId": 17
     }
+  },
+  {
+    "dbName": "test3",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 16
+    },
+    "result": {}
   },
   {
     "dbName": "test3",
     "method": "put",
     "args": {
-      "transactionId": 9,
+      "transactionId": 17,
       "key": "i",
       "value": [
         0,
@@ -685,7 +813,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 9,
+      "transactionId": 17,
       "key": "i"
     },
     "result": {
@@ -696,7 +824,7 @@
     "dbName": "test3",
     "method": "get",
     "args": {
-      "transactionId": 9,
+      "transactionId": 17,
       "key": "i"
     },
     "result": {
@@ -711,7 +839,7 @@
     "dbName": "test3",
     "method": "del",
     "args": {
-      "transactionId": 9,
+      "transactionId": 17,
       "key": "i"
     },
     "result": {
@@ -722,7 +850,7 @@
     "dbName": "test3",
     "method": "has",
     "args": {
-      "transactionId": 9,
+      "transactionId": 17,
       "key": "i"
     },
     "result": {
@@ -733,11 +861,27 @@
     "dbName": "test3",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 9
+      "transactionId": 17
     },
     "result": {
       "ref": "bqmk1odl4frdl3jd3l8e7jmr30ek49kq"
     }
+  },
+  {
+    "dbName": "test3",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 18
+    }
+  },
+  {
+    "dbName": "test3",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 18
+    },
+    "result": {}
   },
   {
     "dbName": "test3",

--- a/src/fixtures/scan.json
+++ b/src/fixtures/scan.json
@@ -144,9 +144,25 @@
   },
   {
     "dbName": "test4",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 2
+    },
+    "result": {}
+  },
+  {
+    "dbName": "test4",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 3
+    }
+  },
+  {
+    "dbName": "test4",
     "method": "scan",
     "args": {
-      "transactionId": 2,
+      "transactionId": 3,
       "limit": 50,
       "prefix": ""
     },
@@ -193,7 +209,7 @@
     "dbName": "test4",
     "method": "closeTransaction",
     "args": {
-      "transactionId": 2
+      "transactionId": 3
     },
     "result": {}
   },
@@ -202,14 +218,14 @@
     "method": "openTransaction",
     "args": {},
     "result": {
-      "transactionId": 3
+      "transactionId": 4
     }
   },
   {
     "dbName": "test4",
     "method": "scan",
     "args": {
-      "transactionId": 3,
+      "transactionId": 4,
       "limit": 50,
       "prefix": "a"
     },
@@ -240,45 +256,6 @@
     "dbName": "test4",
     "method": "closeTransaction",
     "args": {
-      "transactionId": 3
-    },
-    "result": {}
-  },
-  {
-    "dbName": "test4",
-    "method": "openTransaction",
-    "args": {},
-    "result": {
-      "transactionId": 4
-    }
-  },
-  {
-    "dbName": "test4",
-    "method": "scan",
-    "args": {
-      "transactionId": 4,
-      "limit": 50,
-      "prefix": "b"
-    },
-    "result": [
-      {
-        "key": "b/0",
-        "value": 5
-      },
-      {
-        "key": "b/1",
-        "value": 6
-      },
-      {
-        "key": "b/2",
-        "value": 7
-      }
-    ]
-  },
-  {
-    "dbName": "test4",
-    "method": "closeTransaction",
-    "args": {
       "transactionId": 4
     },
     "result": {}
@@ -297,12 +274,20 @@
     "args": {
       "transactionId": 5,
       "limit": 50,
-      "prefix": "c/"
+      "prefix": "b"
     },
     "result": [
       {
-        "key": "c/0",
-        "value": 8
+        "key": "b/0",
+        "value": 5
+      },
+      {
+        "key": "b/1",
+        "value": 6
+      },
+      {
+        "key": "b/2",
+        "value": 7
       }
     ]
   },
@@ -327,21 +312,13 @@
     "method": "scan",
     "args": {
       "transactionId": 6,
-      "limit": 3,
-      "prefix": ""
+      "limit": 50,
+      "prefix": "c/"
     },
     "result": [
       {
-        "key": "a/0",
-        "value": 0
-      },
-      {
-        "key": "a/1",
-        "value": 1
-      },
-      {
-        "key": "a/2",
-        "value": 2
+        "key": "c/0",
+        "value": 8
       }
     ]
   },
@@ -366,16 +343,14 @@
     "method": "scan",
     "args": {
       "transactionId": 7,
-      "limit": 2,
-      "prefix": "",
-      "start": {
-        "id": {
-          "value": "a/1",
-          "exclusive": false
-        }
-      }
+      "limit": 3,
+      "prefix": ""
     },
     "result": [
+      {
+        "key": "a/0",
+        "value": 0
+      },
       {
         "key": "a/1",
         "value": 1
@@ -412,18 +387,18 @@
       "start": {
         "id": {
           "value": "a/1",
-          "exclusive": true
+          "exclusive": false
         }
       }
     },
     "result": [
       {
-        "key": "a/2",
-        "value": 2
+        "key": "a/1",
+        "value": 1
       },
       {
-        "key": "a/3",
-        "value": 3
+        "key": "a/2",
+        "value": 2
       }
     ]
   },
@@ -452,6 +427,47 @@
       "prefix": "",
       "start": {
         "id": {
+          "value": "a/1",
+          "exclusive": true
+        }
+      }
+    },
+    "result": [
+      {
+        "key": "a/2",
+        "value": 2
+      },
+      {
+        "key": "a/3",
+        "value": 3
+      }
+    ]
+  },
+  {
+    "dbName": "test4",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 10
+    }
+  },
+  {
+    "dbName": "test4",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 9
+    },
+    "result": {}
+  },
+  {
+    "dbName": "test4",
+    "method": "scan",
+    "args": {
+      "transactionId": 10,
+      "limit": 2,
+      "prefix": "",
+      "start": {
+        "id": {
           "exclusive": false
         },
         "index": 1
@@ -472,7 +488,7 @@
     "dbName": "test4",
     "method": "closeTransaction",
     "args": {
-      "transactionId": 9
+      "transactionId": 10
     },
     "result": {}
   },

--- a/src/fixtures/subscribe close.json
+++ b/src/fixtures/subscribe close.json
@@ -1,0 +1,110 @@
+[
+  {
+    "dbName": "subscribe-close",
+    "method": "open",
+    "args": {},
+    "result": ""
+  },
+  {
+    "dbName": "subscribe-close",
+    "method": "getRoot",
+    "args": {},
+    "result": {
+      "root": "e99uif9c7bpavajrt666es1ki52dv239"
+    }
+  },
+  {
+    "dbName": "subscribe-close",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 1
+    }
+  },
+  {
+    "dbName": "subscribe-close",
+    "method": "openTransaction",
+    "args": {
+      "args": {
+        "k": 0
+      },
+      "name": "add-data"
+    },
+    "result": {
+      "transactionId": 2
+    }
+  },
+  {
+    "dbName": "subscribe-close",
+    "method": "get",
+    "args": {
+      "transactionId": 1,
+      "key": "k"
+    },
+    "result": {
+      "has": false
+    }
+  },
+  {
+    "dbName": "subscribe-close",
+    "method": "put",
+    "args": {
+      "transactionId": 2,
+      "key": "k",
+      "value": 0
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe-close",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 1
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe-close",
+    "method": "commitTransaction",
+    "args": {
+      "transactionId": 2
+    },
+    "result": {
+      "ref": "tqp56qjgdntdpktfht1vke2qhkahv5fl"
+    }
+  },
+  {
+    "dbName": "subscribe-close",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 3
+    }
+  },
+  {
+    "dbName": "subscribe-close",
+    "method": "get",
+    "args": {
+      "transactionId": 3,
+      "key": "k"
+    },
+    "result": {
+      "has": true,
+      "value": 0
+    }
+  },
+  {
+    "dbName": "subscribe-close",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 3
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe-close",
+    "method": "close",
+    "args": {},
+    "result": ""
+  }
+]

--- a/src/fixtures/subscribe with error.json
+++ b/src/fixtures/subscribe with error.json
@@ -1,0 +1,110 @@
+[
+  {
+    "dbName": "suberr",
+    "method": "open",
+    "args": {},
+    "result": ""
+  },
+  {
+    "dbName": "suberr",
+    "method": "getRoot",
+    "args": {},
+    "result": {
+      "root": "e99uif9c7bpavajrt666es1ki52dv239"
+    }
+  },
+  {
+    "dbName": "suberr",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 1
+    }
+  },
+  {
+    "dbName": "suberr",
+    "method": "openTransaction",
+    "args": {
+      "args": {
+        "k": "throw"
+      },
+      "name": "add-data"
+    },
+    "result": {
+      "transactionId": 2
+    }
+  },
+  {
+    "dbName": "suberr",
+    "method": "get",
+    "args": {
+      "transactionId": 1,
+      "key": "k"
+    },
+    "result": {
+      "has": false
+    }
+  },
+  {
+    "dbName": "suberr",
+    "method": "put",
+    "args": {
+      "transactionId": 2,
+      "key": "k",
+      "value": "throw"
+    },
+    "result": {}
+  },
+  {
+    "dbName": "suberr",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 1
+    },
+    "result": {}
+  },
+  {
+    "dbName": "suberr",
+    "method": "commitTransaction",
+    "args": {
+      "transactionId": 2
+    },
+    "result": {
+      "ref": "fuvlabho49l1kklklp7ifok78j68p58k"
+    }
+  },
+  {
+    "dbName": "suberr",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 3
+    }
+  },
+  {
+    "dbName": "suberr",
+    "method": "get",
+    "args": {
+      "transactionId": 3,
+      "key": "k"
+    },
+    "result": {
+      "has": true,
+      "value": "throw"
+    }
+  },
+  {
+    "dbName": "suberr",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 3
+    },
+    "result": {}
+  },
+  {
+    "dbName": "suberr",
+    "method": "close",
+    "args": {},
+    "result": ""
+  }
+]

--- a/src/fixtures/subscribe.json
+++ b/src/fixtures/subscribe.json
@@ -1,0 +1,448 @@
+[
+  {
+    "dbName": "subscribe",
+    "method": "open",
+    "args": {},
+    "result": ""
+  },
+  {
+    "dbName": "subscribe",
+    "method": "getRoot",
+    "args": {},
+    "result": {
+      "root": "e99uif9c7bpavajrt666es1ki52dv239"
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 1
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {
+      "args": {
+        "a/0": 0
+      },
+      "name": "add-data"
+    },
+    "result": {
+      "transactionId": 2
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "scan",
+    "args": {
+      "transactionId": 1,
+      "limit": 50,
+      "prefix": "a/"
+    },
+    "result": []
+  },
+  {
+    "dbName": "subscribe",
+    "method": "put",
+    "args": {
+      "transactionId": 2,
+      "key": "a/0",
+      "value": 0
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 1
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "commitTransaction",
+    "args": {
+      "transactionId": 2
+    },
+    "result": {
+      "ref": "1urd54h8eang8qlg04a2252jdensto5m"
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 3
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "scan",
+    "args": {
+      "transactionId": 3,
+      "limit": 50,
+      "prefix": "a/"
+    },
+    "result": [
+      {
+        "key": "a/0",
+        "value": 0
+      }
+    ]
+  },
+  {
+    "dbName": "subscribe",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 3
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {
+      "args": {
+        "a/0": 0
+      },
+      "name": "add-data"
+    },
+    "result": {
+      "transactionId": 4
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "put",
+    "args": {
+      "transactionId": 4,
+      "key": "a/0",
+      "value": 0
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "commitTransaction",
+    "args": {
+      "transactionId": 4
+    },
+    "result": {
+      "ref": "hu07btpggcmkc4ujo1bmlvm9o6li3bh0"
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 5
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "scan",
+    "args": {
+      "transactionId": 5,
+      "limit": 50,
+      "prefix": "a/"
+    },
+    "result": [
+      {
+        "key": "a/0",
+        "value": 0
+      }
+    ]
+  },
+  {
+    "dbName": "subscribe",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 5
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {
+      "args": {
+        "a/1": 1
+      },
+      "name": "add-data"
+    },
+    "result": {
+      "transactionId": 6
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "put",
+    "args": {
+      "transactionId": 6,
+      "key": "a/1",
+      "value": 1
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "commitTransaction",
+    "args": {
+      "transactionId": 6
+    },
+    "result": {
+      "ref": "rrv3aqst7so8e9a6kalic5s9etm95dv9"
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 7
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "scan",
+    "args": {
+      "transactionId": 7,
+      "limit": 50,
+      "prefix": "a/"
+    },
+    "result": [
+      {
+        "key": "a/0",
+        "value": 0
+      },
+      {
+        "key": "a/1",
+        "value": 1
+      }
+    ]
+  },
+  {
+    "dbName": "subscribe",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 7
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {
+      "args": {
+        "a/1": 1
+      },
+      "name": "add-data"
+    },
+    "result": {
+      "transactionId": 8
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "put",
+    "args": {
+      "transactionId": 8,
+      "key": "a/1",
+      "value": 1
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "commitTransaction",
+    "args": {
+      "transactionId": 8
+    },
+    "result": {
+      "ref": "1t1l07m370c4k1jbh9cenumcf18ud1qj"
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 9
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "scan",
+    "args": {
+      "transactionId": 9,
+      "limit": 50,
+      "prefix": "a/"
+    },
+    "result": [
+      {
+        "key": "a/0",
+        "value": 0
+      },
+      {
+        "key": "a/1",
+        "value": 1
+      }
+    ]
+  },
+  {
+    "dbName": "subscribe",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 9
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {
+      "args": {
+        "a/1": 11
+      },
+      "name": "add-data"
+    },
+    "result": {
+      "transactionId": 10
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "put",
+    "args": {
+      "transactionId": 10,
+      "key": "a/1",
+      "value": 11
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "commitTransaction",
+    "args": {
+      "transactionId": 10
+    },
+    "result": {
+      "ref": "f326rp67musbvokp4hnai4can925p800"
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 11
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "scan",
+    "args": {
+      "transactionId": 11,
+      "limit": 50,
+      "prefix": "a/"
+    },
+    "result": [
+      {
+        "key": "a/0",
+        "value": 0
+      },
+      {
+        "key": "a/1",
+        "value": 11
+      }
+    ]
+  },
+  {
+    "dbName": "subscribe",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 11
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {
+      "args": {
+        "a/1": 11
+      },
+      "name": "add-data"
+    },
+    "result": {
+      "transactionId": 12
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "put",
+    "args": {
+      "transactionId": 12,
+      "key": "a/1",
+      "value": 11
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "commitTransaction",
+    "args": {
+      "transactionId": 12
+    },
+    "result": {
+      "ref": "ijto1r834e41hqaa2q6sq9hhuvsq2v44"
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 13
+    }
+  },
+  {
+    "dbName": "subscribe",
+    "method": "scan",
+    "args": {
+      "transactionId": 13,
+      "limit": 50,
+      "prefix": "a/"
+    },
+    "result": [
+      {
+        "key": "a/0",
+        "value": 0
+      },
+      {
+        "key": "a/1",
+        "value": 11
+      }
+    ]
+  },
+  {
+    "dbName": "subscribe",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 13
+    },
+    "result": {}
+  },
+  {
+    "dbName": "subscribe",
+    "method": "close",
+    "args": {},
+    "result": ""
+  }
+]

--- a/src/fixtures/sync.json
+++ b/src/fixtures/sync.json
@@ -91,9 +91,9 @@
       "diffServerAuth": "1"
     },
     "result": {
-      "syncHead": "joccnrl5gm1aehankp45tbv9anfjtord",
+      "syncHead": "62f6ki43l12mujhubcfhjuugiause17b",
       "syncInfo": {
-        "syncID": "mNBJicAp7cDxV2QunKLYYE-5ed81b38-1",
+        "syncID": "XY6WhbbdeUdytMJNtsBejG-5ed87fed-1",
         "clientViewInfo": {
           "httpStatusCode": 200,
           "errorMessage": ""
@@ -105,8 +105,24 @@
     "dbName": "sync",
     "method": "maybeEndSync",
     "args": {
-      "syncID": "mNBJicAp7cDxV2QunKLYYE-5ed81b38-1",
-      "syncHead": "joccnrl5gm1aehankp45tbv9anfjtord"
+      "syncID": "XY6WhbbdeUdytMJNtsBejG-5ed87fed-1",
+      "syncHead": "62f6ki43l12mujhubcfhjuugiause17b"
+    },
+    "result": {}
+  },
+  {
+    "dbName": "sync",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 3
+    }
+  },
+  {
+    "dbName": "sync",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 3
     },
     "result": {}
   },
@@ -122,7 +138,7 @@
     "result": {
       "syncHead": "00000000000000000000000000000000",
       "syncInfo": {
-        "syncID": "mNBJicAp7cDxV2QunKLYYE-5ed81b38-2",
+        "syncID": "XY6WhbbdeUdytMJNtsBejG-5ed87fed-2",
         "clientViewInfo": {
           "httpStatusCode": 200,
           "errorMessage": ""
@@ -144,14 +160,14 @@
       "name": "createTodo"
     },
     "result": {
-      "transactionId": 3
+      "transactionId": 4
     }
   },
   {
     "dbName": "sync",
     "method": "put",
     "args": {
-      "transactionId": 3,
+      "transactionId": 4,
       "key": "/todo/14323534",
       "value": {
         "id": 14323534,
@@ -167,10 +183,10 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 3
+      "transactionId": 4
     },
     "result": {
-      "ref": "uikn5klbnukgg5c72u069kq4lt56m4u9"
+      "ref": "jcm71mr1qn7c4hrl0t1icv8eug3q6t4q"
     }
   },
   {
@@ -178,14 +194,30 @@
     "method": "openTransaction",
     "args": {},
     "result": {
-      "transactionId": 4
+      "transactionId": 5
+    }
+  },
+  {
+    "dbName": "sync",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 5
+    },
+    "result": {}
+  },
+  {
+    "dbName": "sync",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 6
     }
   },
   {
     "dbName": "sync",
     "method": "get",
     "args": {
-      "transactionId": 4,
+      "transactionId": 6,
       "key": "/todo/14323534"
     },
     "result": {
@@ -203,7 +235,7 @@
     "dbName": "sync",
     "method": "closeTransaction",
     "args": {
-      "transactionId": 4
+      "transactionId": 6
     },
     "result": {}
   },
@@ -217,9 +249,9 @@
       "diffServerAuth": "1"
     },
     "result": {
-      "syncHead": "472b9pfehsqb6c7j80v8dk8m2evjoall",
+      "syncHead": "o765nohuq5odu3l595dumucsnhflmqpl",
       "syncInfo": {
-        "syncID": "mNBJicAp7cDxV2QunKLYYE-5ed81b38-3",
+        "syncID": "XY6WhbbdeUdytMJNtsBejG-5ed87fed-3",
         "batchPushInfo": {
           "httpStatusCode": 200,
           "errorMessage": "",
@@ -246,14 +278,14 @@
       "name": "createTodo"
     },
     "result": {
-      "transactionId": 5
+      "transactionId": 7
     }
   },
   {
     "dbName": "sync",
     "method": "put",
     "args": {
-      "transactionId": 5,
+      "transactionId": 7,
       "key": "/todo/22354345",
       "value": {
         "id": 22354345,
@@ -269,10 +301,10 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 5
+      "transactionId": 7
     },
     "result": {
-      "ref": "hg9qrbuq2qhabjkffhcn61uoch67tjfu"
+      "ref": "01o95tco2mfa9cbtg77qh3plmrq97i63"
     }
   },
   {
@@ -280,14 +312,30 @@
     "method": "openTransaction",
     "args": {},
     "result": {
-      "transactionId": 6
+      "transactionId": 8
     }
+  },
+  {
+    "dbName": "sync",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 9
+    }
+  },
+  {
+    "dbName": "sync",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 8
+    },
+    "result": {}
   },
   {
     "dbName": "sync",
     "method": "get",
     "args": {
-      "transactionId": 6,
+      "transactionId": 9,
       "key": "/todo/22354345"
     },
     "result": {
@@ -305,7 +353,7 @@
     "dbName": "sync",
     "method": "closeTransaction",
     "args": {
-      "transactionId": 6
+      "transactionId": 9
     },
     "result": {}
   },
@@ -313,8 +361,8 @@
     "dbName": "sync",
     "method": "maybeEndSync",
     "args": {
-      "syncID": "mNBJicAp7cDxV2QunKLYYE-5ed81b38-3",
-      "syncHead": "472b9pfehsqb6c7j80v8dk8m2evjoall"
+      "syncID": "XY6WhbbdeUdytMJNtsBejG-5ed87fed-3",
+      "syncHead": "o765nohuq5odu3l595dumucsnhflmqpl"
     },
     "result": {
       "replayMutations": [
@@ -328,7 +376,7 @@
             "order": 20000,
             "text": "Test 2"
           },
-          "original": "hg9qrbuq2qhabjkffhcn61uoch67tjfu"
+          "original": "01o95tco2mfa9cbtg77qh3plmrq97i63"
         }
       ]
     }
@@ -346,19 +394,19 @@
       },
       "name": "createTodo",
       "rebaseOpts": {
-        "basis": "472b9pfehsqb6c7j80v8dk8m2evjoall",
-        "original": "hg9qrbuq2qhabjkffhcn61uoch67tjfu"
+        "basis": "o765nohuq5odu3l595dumucsnhflmqpl",
+        "original": "01o95tco2mfa9cbtg77qh3plmrq97i63"
       }
     },
     "result": {
-      "transactionId": 7
+      "transactionId": 10
     }
   },
   {
     "dbName": "sync",
     "method": "put",
     "args": {
-      "transactionId": 7,
+      "transactionId": 10,
       "key": "/todo/22354345",
       "value": {
         "complete": false,
@@ -374,18 +422,34 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 7
+      "transactionId": 10
     },
     "result": {
-      "ref": "9kg655lq25vuf721qvnmd7ai4abgnccb"
+      "ref": "2edu4qsv6j5l4e006jg5oocu0qvmoktv"
     }
   },
   {
     "dbName": "sync",
     "method": "maybeEndSync",
     "args": {
-      "syncID": "mNBJicAp7cDxV2QunKLYYE-5ed81b38-3",
-      "syncHead": "9kg655lq25vuf721qvnmd7ai4abgnccb"
+      "syncID": "XY6WhbbdeUdytMJNtsBejG-5ed87fed-3",
+      "syncHead": "2edu4qsv6j5l4e006jg5oocu0qvmoktv"
+    },
+    "result": {}
+  },
+  {
+    "dbName": "sync",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 11
+    }
+  },
+  {
+    "dbName": "sync",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 11
     },
     "result": {}
   },
@@ -399,14 +463,14 @@
       "name": "deleteTodo"
     },
     "result": {
-      "transactionId": 8
+      "transactionId": 12
     }
   },
   {
     "dbName": "sync",
     "method": "del",
     "args": {
-      "transactionId": 8,
+      "transactionId": 12,
       "key": "/todo/14323534"
     },
     "result": {
@@ -417,10 +481,18 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 8
+      "transactionId": 12
     },
     "result": {
-      "ref": "h1tpn9022nspv5tdvh6tf3r241usqh1b"
+      "ref": "fr7h1uuugdlacdpdjfb7ssn2ofuvoqv5"
+    }
+  },
+  {
+    "dbName": "sync",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 13
     }
   },
   {
@@ -433,14 +505,22 @@
       "name": "deleteTodo"
     },
     "result": {
-      "transactionId": 9
+      "transactionId": 14
     }
+  },
+  {
+    "dbName": "sync",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 13
+    },
+    "result": {}
   },
   {
     "dbName": "sync",
     "method": "del",
     "args": {
-      "transactionId": 9,
+      "transactionId": 14,
       "key": "/todo/22354345"
     },
     "result": {
@@ -451,11 +531,27 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "args": {
-      "transactionId": 9
+      "transactionId": 14
     },
     "result": {
-      "ref": "21srq6usqliao7452qgm9fnk09ubnk02"
+      "ref": "5dg1c34pdnpk1fvg1netha0cpsc4mmks"
     }
+  },
+  {
+    "dbName": "sync",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 15
+    }
+  },
+  {
+    "dbName": "sync",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 15
+    },
+    "result": {}
   },
   {
     "dbName": "sync",
@@ -467,9 +563,9 @@
       "diffServerAuth": "1"
     },
     "result": {
-      "syncHead": "qfca4v424asg4fbvfac13t52t931vkn9",
+      "syncHead": "i2eqbh68mmpdrbm0q64mpkob112b2ru2",
       "syncInfo": {
-        "syncID": "mNBJicAp7cDxV2QunKLYYE-5ed81b38-4",
+        "syncID": "XY6WhbbdeUdytMJNtsBejG-5ed87fed-4",
         "batchPushInfo": {
           "httpStatusCode": 200,
           "errorMessage": "",
@@ -486,8 +582,24 @@
     "dbName": "sync",
     "method": "maybeEndSync",
     "args": {
-      "syncID": "mNBJicAp7cDxV2QunKLYYE-5ed81b38-4",
-      "syncHead": "qfca4v424asg4fbvfac13t52t931vkn9"
+      "syncID": "XY6WhbbdeUdytMJNtsBejG-5ed87fed-4",
+      "syncHead": "i2eqbh68mmpdrbm0q64mpkob112b2ru2"
+    },
+    "result": {}
+  },
+  {
+    "dbName": "sync",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 16
+    }
+  },
+  {
+    "dbName": "sync",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 16
     },
     "result": {}
   },

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -3,6 +3,10 @@ import fetch from 'node-fetch';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).fetch = fetch;
 
+import {ReadableStream} from 'web-streams-polyfill';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).ReadableStream = ReadableStream;
+
 import {open} from 'fs/promises';
 import type {FileHandle} from 'fs/promises';
 
@@ -12,6 +16,7 @@ import {RepmHttpInvoker} from './mod.js';
 import type {RepmInvoke, ReadTransaction, WriteTransaction} from './mod.js';
 import type {JsonType} from './json.js';
 import type {InvokeMapNoArgs, InvokeMap, FullInvoke} from './repm-invoker.js';
+import type {ScanItem} from './scan-item.js';
 
 let rep: ReplicacheTest | null = null;
 let rep2: ReplicacheTest | null = null;
@@ -249,7 +254,7 @@ test('get, has, scan on empty db', async () => {
   rep = await replicacheForTesting('test2');
 
   async function t(tx: ReadTransaction) {
-    expect(await tx.get('key')).toBeNull();
+    expect(await tx.get('key')).toBeUndefined();
     expect(await tx.has('key')).toBe(false);
 
     const scanItems = await tx.scan();
@@ -376,12 +381,146 @@ test('scan', async () => {
   ]);
 });
 
-test.skip('subscribe', async () => {
-  //
+function listen<R>(
+  s: {getReader: ReadableStream['getReader']},
+  callback: (r: R) => void,
+) {
+  let cancelled = false;
+  let paused = false;
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  let onDone = () => {};
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  let onError: (e: unknown) => void = () => {};
+
+  async function inner<R>(
+    s: {getReader: ReadableStream['getReader']},
+    callback: (r: R) => void,
+  ) {
+    const reader = s.getReader();
+    try {
+      for (;;) {
+        const res = await reader.read();
+        if (cancelled || res.done) {
+          return;
+        }
+        if (!paused) {
+          callback(res.value);
+        }
+      }
+    } catch (e) {
+      onError(e);
+    } finally {
+      reader.releaseLock();
+      onDone();
+    }
+  }
+
+  inner(s, callback);
+
+  return {
+    cancel() {
+      cancelled = true;
+    },
+    pause() {
+      paused = true;
+    },
+    resume() {
+      paused = false;
+    },
+    onDone(f: () => void) {
+      onDone = f;
+    },
+    onError(f: (e: unknown) => void) {
+      onError = f;
+    },
+  };
+}
+
+test('subscribe', async () => {
+  await useReplay('subscribe');
+
+  rep = await replicacheForTesting('subscribe');
+  const repSub = rep.subscribe(
+    async (tx: ReadTransaction) => await tx.scan({prefix: 'a/'}),
+  );
+
+  const log: ScanItem[] = [];
+
+  const sub = listen(repSub, (values: Iterable<ScanItem>) => {
+    for (const scanItem of values) {
+      log.push(scanItem);
+    }
+  });
+
+  expect(log).toHaveLength(0);
+
+  const add = rep.register('add-data', addData);
+  await add({'a/0': 0});
+  await Promise.resolve();
+  expect(log).toEqual([{key: 'a/0', value: 0}]);
+
+  // We might potentially remove this entry if we start checking equality.
+  log.length = 0;
+  await add({'a/0': 0});
+  await Promise.resolve();
+  expect(log).toEqual([{key: 'a/0', value: 0}]);
+
+  log.length = 0;
+  await add({'a/1': 1});
+  await Promise.resolve();
+  expect(log).toEqual([
+    {key: 'a/0', value: 0},
+    {key: 'a/1', value: 1},
+  ]);
+
+  log.length = 0;
+  sub.pause();
+  await add({'a/1': 1});
+  await Promise.resolve();
+  expect(log).toHaveLength(0);
+
+  log.length = 0;
+  sub.resume();
+  await add({'a/1': 11});
+  await Promise.resolve();
+  expect(log).toEqual([
+    {key: 'a/0', value: 0},
+    {key: 'a/1', value: 11},
+  ]);
+
+  log.length = 0;
+  sub.cancel();
+  await add({'a/1': 11});
+  await Promise.resolve();
+  expect(log).toHaveLength(0);
 });
 
-test.skip('subscribe close', async () => {
-  //
+test('subscribe close', async () => {
+  await useReplay('subscribe close');
+
+  rep = await replicacheForTesting('subscribe-close');
+  const repSub = rep.subscribe((tx: ReadTransaction) => tx.get('k'));
+
+  const log: (number | undefined)[] = [];
+  const sub = listen(repSub, (value: number | undefined) => {
+    log.push(value);
+  });
+
+  expect(log).toHaveLength(0);
+
+  const add = rep.register('add-data', addData);
+  await add({k: 0});
+  await Promise.resolve();
+  expect(log).toEqual([undefined, 0]);
+
+  let done = false;
+  sub.onDone(() => {
+    done = true;
+  });
+
+  await rep.close();
+  expect(done).toBe(true);
+  sub.cancel();
 });
 
 test('name', async () => {
@@ -420,8 +559,40 @@ test('register with error', async () => {
   }
 });
 
-test.skip('subscribe with error', async () => {
-  //
+test('subscribe with error', async () => {
+  await useReplay('subscribe with error');
+
+  rep = await replicacheForTesting('suberr');
+
+  const add = rep.register('add-data', addData);
+
+  const repSub = rep.subscribe(async tx => {
+    const v = await tx.get('k');
+    if (v !== undefined && v !== null) {
+      throw v;
+    }
+  });
+  await Promise.resolve();
+
+  let gottenValue = 0;
+  const sub = listen(repSub, () => {
+    gottenValue++;
+  });
+
+  let error;
+  sub.onError(e => {
+    error = e;
+  });
+
+  expect(error).toBeUndefined();
+  expect(gottenValue).toBe(0);
+
+  await add({k: 'throw'});
+  expect(gottenValue).toBe(1);
+  await Promise.resolve();
+  expect(error).toBe('throw');
+
+  await sub.cancel();
 });
 
 test('conflicting commits', async () => {

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -9,9 +9,10 @@ import type {Invoke, ScanRequest} from './repm-invoker.js';
  */
 export interface ReadTransaction {
   /**
-   * Get a single value from the database.
+   * Get a single value from the database. If the key is not present this
+   * returns `undefined`.
    */
-  get(key: string): Promise<JsonType>;
+  get(key: string): Promise<JsonType | undefined>;
 
   /**
    * Determines if a single key is present in the database.
@@ -33,13 +34,13 @@ export class ReadTransactionImpl implements ReadTransaction {
     this._transactionId = transactionId;
   }
 
-  async get(key: string): Promise<JsonType> {
+  async get(key: string): Promise<JsonType | undefined> {
     const result = await this._invoke('get', {
       transactionId: this._transactionId,
       key: key,
     });
     if (!result['has']) {
-      return null;
+      return undefined;
     }
     return result['value'];
   }


### PR DESCRIPTION
This uses a ReadableStream which is defined in the DOM. For NodeJS we
need a third part library which is unfortunate.

It is also not clear if this is a good fit.
 - ReadableStream only allows a single error. After the stream errors it
   becomes unusable.
 - The API is not as convenient as the Dart one. If using async iterator
   it is nice but there is no imperative API around it.