### PR TITLE
Needs to use a non empty name by default

### DIFF
--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -66,7 +66,7 @@ export default class Replicache implements ReadTransaction {
     dataLayerAuth = '',
     diffServerAuth = '',
     diffServerURL,
-    name = '',
+    name = 'default',
     repmInvoke,
   }: {
     batchURL?: string;


### PR DESCRIPTION
The name used to be the diff server URL...