### PR TITLE
WIP: Use AsyncIterable for scan

### DIFF
--- a/docs/classes/replicache.html
+++ b/docs/classes/replicache.html
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L62">replicache.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L62">replicache.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Data<wbr>Layer<wbr>Auth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">MaybePromise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L59">replicache.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L59">replicache.ts:59</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">on<wbr>Sync<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>syncing<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L52">replicache.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L52">replicache.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L123">replicache.ts:123</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L123">replicache.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -224,7 +224,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L119">replicache.ts:119</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L119">replicache.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -242,7 +242,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L131">replicache.ts:131</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L131">replicache.ts:131</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -256,7 +256,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L134">replicache.ts:134</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L134">replicache.ts:134</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -288,7 +288,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L149">replicache.ts:149</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L149">replicache.ts:149</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -306,7 +306,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/readtransaction.html">ReadTransaction</a>.<a href="../interfaces/readtransaction.html#get">get</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L189">replicache.ts:189</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L189">replicache.ts:189</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -335,7 +335,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/readtransaction.html">ReadTransaction</a>.<a href="../interfaces/readtransaction.html#has">has</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L194">replicache.ts:194</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L194">replicache.ts:194</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -363,7 +363,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L439">replicache.ts:439</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L443">replicache.ts:443</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -417,7 +417,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L482">replicache.ts:482</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L486">replicache.ts:486</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -479,13 +479,13 @@
 					<a name="scan" class="tsd-anchor"></a>
 					<h3>scan</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">scan<span class="tsd-signature-symbol">(</span>__namedParameters<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-symbol">{ </span>limit<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>prefix<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>start<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><a href="../interfaces/scanbound.html" class="tsd-signature-type">ScanBound</a><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Iterable</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/scanitem.html" class="tsd-signature-type">ScanItem</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">scan<span class="tsd-signature-symbol">(</span>__namedParameters<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-symbol">{ </span>limit<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>prefix<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>start<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><a href="../interfaces/scanbound.html" class="tsd-signature-type">ScanBound</a><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">AsyncIterable</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/scanitem.html" class="tsd-signature-type">ScanItem</a><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L199">replicache.ts:199</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L199">replicache.ts:199</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -510,7 +510,7 @@
 									</ul>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Iterable</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/scanitem.html" class="tsd-signature-type">ScanItem</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AsyncIterable</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/scanitem.html" class="tsd-signature-type">ScanItem</a><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>
@@ -524,7 +524,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L407">replicache.ts:407</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L411">replicache.ts:411</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -630,7 +630,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L342">replicache.ts:342</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L346">replicache.ts:346</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -656,7 +656,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L112">replicache.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L112">replicache.ts:112</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -692,7 +692,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L91">replicache.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L91">replicache.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/repmhttpinvoker.html
+++ b/docs/classes/repmhttpinvoker.html
@@ -101,7 +101,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/repm-invoker.ts#L27">repm-invoker.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/repm-invoker.ts#L27">repm-invoker.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/repm-invoker.ts#L32">repm-invoker.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/repm-invoker.ts#L32">repm-invoker.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">Database<wbr>Info<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/database-info.ts#L4">database-info.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/database-info.ts#L4">database-info.ts:4</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mutator&lt;Return, Args&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Args</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Return</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/replicache.ts#L13">replicache.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/replicache.ts#L13">replicache.ts:13</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,36 +64,49 @@
 					<h1>Replicache JS SDK</h1>
 				</a>
 				<p><img src="https://github.com/rocicorp/replicache-sdk-js/workflows/Node.js%20CI/badge.svg" alt="Node.js CI"></p>
-				<a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
-					<h2>Getting Started</h2>
+				<a href="#development-instructions" id="development-instructions" style="color: inherit; text-decoration: none;">
+					<h2>Development Instructions</h2>
 				</a>
 				<p>Eventually you will be able to <code>npm install</code> but until then...</p>
-				<a href="#prerequisites" id="prerequisites" style="color: inherit; text-decoration: none;">
-					<h2>Prerequisites</h2>
-				</a>
-				<ul>
-					<li>NodeJS/NPM</li>
-				</ul>
-				<a href="#building-the-code" id="building-the-code" style="color: inherit; text-decoration: none;">
-					<h2>Building the code</h2>
-				</a>
 				<a href="#get-the-code" id="get-the-code" style="color: inherit; text-decoration: none;">
 					<h3>Get the Code</h3>
 				</a>
-				<p>Download the <a href="https://github.com/rocicorp/replicache-sdk-js/releases">latest release</a> from Github. It&#39;s important to get the typescript and binary from a release to ensure you have the correct version of the binary.</p>
+				<p>Either by <code>npm install</code>&#39;ing the git repo, cloning it, or downloading a
+				release.</p>
 				<a href="#build-the-js" id="build-the-js" style="color: inherit; text-decoration: none;">
 					<h3>Build the JS</h3>
 				</a>
 				<p>Replicache JS SDK is written in TypeScript. Run <code>npm run build</code> to generate the JS source code (JS source is outputted in <code>out/</code>). By default we generate browser compatible JS but you can also build CommonJS modules by running <code>npm run build:cjs</code>. Let us know what your needs are.</p>
-				<a href="#run-the-binary" id="run-the-binary" style="color: inherit; text-decoration: none;">
-					<h2>Run the binary</h2>
+				<a href="#get-binaries" id="get-binaries" style="color: inherit; text-decoration: none;">
+					<h3>Get Binaries</h3>
 				</a>
-				<p>The Replicache Client binary was originally developed as a quick way to test the Replicache Client API. Eventually we will use a WASM version or have Electron/NodeJS start the binary automatically. But for now we need to manually start it.</p>
-				<pre><code class="language-sh">./repm-{arch}-{platform} --no-fake-time</code></pre>
-				<p>This starts an HTTP server on port 7002 (by default, use <code>--port</code> to change.)</p>
-				<p>We need to use the <code>--no-fake-time</code> flag for now or all the timestamps will be using a fake time.</p>
+				<p>Download required helper binaries: <code>npm run build:binaries</code>. Do this again whenever you update the SDK.</p>
+				<a href="#run-test-server" id="run-test-server" style="color: inherit; text-decoration: none;">
+					<h3>Run <code>test-server</code></h3>
+				</a>
+				<p>Currently, the JavaScript SDK relies on a native local server that
+					implements the guts of the sync protocol on the client side. This is
+				temporary and will be removed.</p>
+				<p>For now, you must have this server running whenever you are working
+				with the SDK: <code>npm run start:test-server</code>.</p>
+				<a href="#start-your-data-layer" id="start-your-data-layer" style="color: inherit; text-decoration: none;">
+					<h3>Start your Data Layer</h3>
+				</a>
+				<p>See <a href="https://github.com/rocicorp/replicache#server-side">Replicache Server Setup</a> for server-side instructions.</p>
+				<p>For the rest of these instructions we will assume your data layer is
+				running on <code>localhost:3000</code>.</p>
+				<a href="#start-diff-server" id="start-diff-server" style="color: inherit; text-decoration: none;">
+					<h3>Start Diff-Server</h3>
+				</a>
+				<p>In production, your app will talk to the production Replicache diff-server at <a href="https://serve.replicache.dev/">https://serve.replicache.dev/</a>.</p>
+				<p>During development, that sever can&#39;t reach your workstation, so we
+					provide a development instance to work against instead. Leave this
+				running in a tab:</p>
+				<pre><code class="language-bash"><span class="hljs-comment"># The --client-view flag should point to the Client View endpoint</span>
+<span class="hljs-comment"># on your development data layer.</span>
+npm run start:diff-server -- --client-view=<span class="hljs-string">"http://localhost:3000/replicache-client-view"</span></code></pre>
 				<a href="#including-the-js" id="including-the-js" style="color: inherit; text-decoration: none;">
-					<h1>Including the JS</h1>
+					<h3>Including the JS</h3>
 				</a>
 				<p>By default we only compile the TS to an ES module.</p>
 				<pre><code class="language-js"><span class="hljs-keyword">import</span> Replicache, {REPMHTTPInvoker} <span class="hljs-keyword">from</span> <span class="hljs-string">'./out/mod.js'</span>;</code></pre>

--- a/docs/interfaces/readtransaction.html
+++ b/docs/interfaces/readtransaction.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/transactions.ts#L15">transactions.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/transactions.ts#L15">transactions.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -145,7 +145,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/transactions.ts#L20">transactions.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/transactions.ts#L20">transactions.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,13 +167,13 @@
 					<a name="scan" class="tsd-anchor"></a>
 					<h3>scan</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">scan<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ScanOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Iterable</span><span class="tsd-signature-symbol">&lt;</span><a href="scanitem.html" class="tsd-signature-type">ScanItem</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">scan<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ScanOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">AsyncIterable</span><span class="tsd-signature-symbol">&lt;</span><a href="scanitem.html" class="tsd-signature-type">ScanItem</a><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/transactions.ts#L25">transactions.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/transactions.ts#L25">transactions.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -187,7 +187,7 @@
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <span class="tsd-signature-type">ScanOptions</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Iterable</span><span class="tsd-signature-symbol">&lt;</span><a href="scanitem.html" class="tsd-signature-type">ScanItem</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AsyncIterable</span><span class="tsd-signature-symbol">&lt;</span><a href="scanitem.html" class="tsd-signature-type">ScanItem</a><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>

--- a/docs/interfaces/repminvoke.html
+++ b/docs/interfaces/repminvoke.html
@@ -81,7 +81,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/repm-invoker.ts#L14">repm-invoker.ts:14</a></li>
+								<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/repm-invoker.ts#L14">repm-invoker.ts:14</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -104,7 +104,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/repm-invoker.ts#L17">repm-invoker.ts:17</a></li>
+								<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/repm-invoker.ts#L17">repm-invoker.ts:17</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -130,7 +130,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/repm-invoker.ts#L22">repm-invoker.ts:22</a></li>
+								<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/repm-invoker.ts#L22">repm-invoker.ts:22</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/scanbound.html
+++ b/docs/interfaces/scanbound.html
@@ -92,7 +92,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <a href="scanid.html" class="tsd-signature-type">ScanId</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/scan-bound.ts#L4">scan-bound.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/scan-bound.ts#L4">scan-bound.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">index<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/scan-bound.ts#L5">scan-bound.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/scan-bound.ts#L5">scan-bound.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/scanid.html
+++ b/docs/interfaces/scanid.html
@@ -92,7 +92,7 @@
 					<div class="tsd-signature tsd-kind-icon">exclusive<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">false</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/scan-id.ts#L3">scan-id.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/scan-id.ts#L3">scan-id.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/scan-id.ts#L2">scan-id.ts:2</a></li>
+							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/scan-id.ts#L2">scan-id.ts:2</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/scanitem.html
+++ b/docs/interfaces/scanitem.html
@@ -92,7 +92,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/scan-item.ts#L4">scan-item.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/scan-item.ts#L4">scan-item.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">JSONValue</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/scan-item.ts#L5">scan-item.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/scan-item.ts#L5">scan-item.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/writetransaction.html
+++ b/docs/interfaces/writetransaction.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/transactions.ts#L88">transactions.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/transactions.ts#L93">transactions.ts:93</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="readtransaction.html">ReadTransaction</a>.<a href="readtransaction.html#get">get</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/transactions.ts#L15">transactions.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/transactions.ts#L15">transactions.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="readtransaction.html">ReadTransaction</a>.<a href="readtransaction.html#has">has</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/transactions.ts#L20">transactions.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/transactions.ts#L20">transactions.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/transactions.ts#L82">transactions.ts:82</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/transactions.ts#L87">transactions.ts:87</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -226,14 +226,14 @@
 					<a name="scan" class="tsd-anchor"></a>
 					<h3>scan</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">scan<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ScanOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Iterable</span><span class="tsd-signature-symbol">&lt;</span><a href="scanitem.html" class="tsd-signature-type">ScanItem</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">scan<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ScanOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">AsyncIterable</span><span class="tsd-signature-symbol">&lt;</span><a href="scanitem.html" class="tsd-signature-type">ScanItem</a><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="readtransaction.html">ReadTransaction</a>.<a href="readtransaction.html#scan">scan</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/96c16de/src/transactions.ts#L25">transactions.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/rocicorp/replicache-sdk-js/blob/98d9003/src/transactions.ts#L25">transactions.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -247,7 +247,7 @@
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <span class="tsd-signature-type">ScanOptions</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Iterable</span><span class="tsd-signature-symbol">&lt;</span><a href="scanitem.html" class="tsd-signature-type">ScanItem</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AsyncIterable</span><span class="tsd-signature-symbol">&lt;</span><a href="scanitem.html" class="tsd-signature-type">ScanItem</a><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>

--- a/sample/redo/src/App.tsx
+++ b/sample/redo/src/App.tsx
@@ -220,10 +220,11 @@ function registerMutations(rep: Replicache) {
 }
 
 async function allTodosInTx(tx: ReadTransaction): Promise<Todo[]> {
-  return Array.from(
-    await tx.scan({prefix, limit: 500}),
-    si => si.value as Todo,
-  );
+  const todos: Todo[] = [];
+  for await (const {value} of tx.scan({prefix, limit: 500})) {
+    todos.push(value as Todo);
+  }
+  return todos;
 }
 
 function todosInList(allTodos: Todo[], listId: number | null): Todo[] {
@@ -233,10 +234,11 @@ function todosInList(allTodos: Todo[], listId: number | null): Todo[] {
 }
 
 async function allListsInTx(tx: ReadTransaction): Promise<number[]> {
-  return Array.from(
-    await tx.scan({prefix: '/list/', limit: 500}),
-    item => (item.value as {id: number}).id,
-  );
+  const listIds: number[] = [];
+  for await (const {value} of tx.scan({prefix: '/list/', limit: 500})) {
+    listIds.push((value as {id: number}).id);
+  }
+  return listIds;
 }
 
 export type Todo = {

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -196,10 +196,14 @@ export default class Replicache implements ReadTransaction {
   }
 
   /** Gets many values from the database. */
-  scan({prefix = '', start, limit = 50}: ScanOptions = {}): Promise<
-    Iterable<ScanItem>
-  > {
-    return this.query(tx => tx.scan({prefix, start, limit}));
+  async *scan({
+    prefix = '',
+    start,
+    limit = 50,
+  }: ScanOptions = {}): AsyncIterable<ScanItem> {
+    yield* await this.query(async tx => {
+      return tx.scan({prefix, start, limit});
+    });
   }
 
   private async _sync(): Promise<void> {

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -22,7 +22,7 @@ export interface ReadTransaction {
   /**
    * Gets many values from the database.
    */
-  scan(options?: ScanOptions): Promise<Iterable<ScanItem>>;
+  scan(options?: ScanOptions): AsyncIterable<ScanItem>;
 }
 
 export class ReadTransactionImpl implements ReadTransaction {
@@ -53,9 +53,11 @@ export class ReadTransactionImpl implements ReadTransaction {
     return result['has'];
   }
 
-  async scan({prefix = '', start, limit = 50}: ScanOptions = {}): Promise<
-    Iterable<ScanItem>
-  > {
+  async *scan({
+    prefix = '',
+    start,
+    limit = 50,
+  }: ScanOptions = {}): AsyncIterable<ScanItem> {
     const args: ScanRequest = {
       transactionId: this._transactionId,
       limit: limit,
@@ -66,7 +68,10 @@ export class ReadTransactionImpl implements ReadTransaction {
     if (start !== undefined) {
       args.start = start;
     }
-    return await this._invoke('scan', args);
+    const scanItems = await this._invoke('scan', args);
+    for (const scanItem of scanItems) {
+      yield scanItem;
+    }
   }
 }
 


### PR DESCRIPTION
Towards #30

This changes scan to return `AsyncIterable<ScanItem>`  instead of
`Promise<Iterable<ScanItem>>`.

It mostly feels right but JS lacks API to work with these things so map,
filter etc needs to be replaced with for loops to profit from the
async iteration.