### PR TITLE
A series of minor fixes that establish a baselines scan performance of about 30MB/s.

### DIFF
--- a/sample/perf/index.html
+++ b/sample/perf/index.html
@@ -101,7 +101,7 @@
     log(`Running benchmarks with ${invoker.constructor.name} please wait...`)
     await benchmark((bench) => benchmark_populate(invoker, bench, { numKeys: 1000, parallel: false }));
     await benchmark((bench) => benchmark_populate(invoker, bench, { numKeys: 1000, parallel: true }));
-    await benchmark((bench) => benchmark_scan(invoker, bench, { numKeys: 1000 }));
+    await benchmark((bench) => benchmark_scan(invoker, bench, { numKeys: 5000 }));
     log('Done!');
   }
 

--- a/sample/perf/index.html
+++ b/sample/perf/index.html
@@ -22,19 +22,10 @@
     });
   }
 
-  async function populate(rep, { numKeys, parallel }) {
+  async function populate(rep, { numKeys }) {
     var set = rep.register('populate', async (tx, args) => {
-      var promises = [];
       for (var i = 0; i < numKeys; i++) {
-        var p = tx.put(`key${i}`, value);
-        if (parallel) {
-          promises.push(p);
-        } else {
-          await p;
-        }
-      }
-      if (promises.length) {
-        await Promise.all(promises);
+        await tx.put(`key${i}`, value);
       }
     });
     await set({});
@@ -43,8 +34,11 @@
   async function benchmark_populate(invoker, bench, opts) {
     var rep = await makeRep(invoker);
     const valSize = value.length;
+    if (!opts.clean) {
+      await populate(rep, opts);
+    }
     bench.reset();
-    bench.setName(`populate ${valSize}x${opts.numKeys} (${opts.parallel ? 'parallel' : 'serial'})`);
+    bench.setName(`populate ${valSize}x${opts.numKeys} (${opts.clean ? 'clean' : 'dirty'})`);
     bench.setSize(opts.numKeys * valSize);
     await populate(rep, opts);
   }
@@ -100,8 +94,8 @@
 
   window.main = async function (invoker) {
     log(`Running benchmarks with ${invoker.constructor.name} please wait...`)
-    await benchmark((bench) => benchmark_populate(invoker, bench, { numKeys: 1000, parallel: false }));
-    await benchmark((bench) => benchmark_populate(invoker, bench, { numKeys: 1000, parallel: true }));
+    await benchmark((bench) => benchmark_populate(invoker, bench, { numKeys: 1000, clean: true }));
+    await benchmark((bench) => benchmark_populate(invoker, bench, { numKeys: 1000, clean: false }));
     await benchmark((bench) => benchmark_scan(invoker, bench, { numKeys: 1000 }));
     await benchmark((bench) => benchmark_scan(invoker, bench, { numKeys: 5000 }));
     log('Done!');

--- a/sample/perf/index.html
+++ b/sample/perf/index.html
@@ -110,6 +110,9 @@
 </script>
 
 <p>
+  <b>IMPORTANT:</b> Close web inspector to get accurate benchmark results.
+
+<p>
   <button onclick='main(wasmInvoker)'>Run Rust Benchmarks</button>
   <button onclick='main(httpInvoker)'>Run Go Benchmarks</button>
 

--- a/sample/perf/index.html
+++ b/sample/perf/index.html
@@ -16,6 +16,7 @@
       dataLayerAuth: '',
       diffServerAuth: '',
       diffServerURL: '',
+      name,
       repmInvoker,
       syncInterval: null,
     });

--- a/sample/perf/index.html
+++ b/sample/perf/index.html
@@ -102,6 +102,7 @@
     log(`Running benchmarks with ${invoker.constructor.name} please wait...`)
     await benchmark((bench) => benchmark_populate(invoker, bench, { numKeys: 1000, parallel: false }));
     await benchmark((bench) => benchmark_populate(invoker, bench, { numKeys: 1000, parallel: true }));
+    await benchmark((bench) => benchmark_scan(invoker, bench, { numKeys: 1000 }));
     await benchmark((bench) => benchmark_scan(invoker, bench, { numKeys: 5000 }));
     log('Done!');
   }

--- a/sample/perf/index.html
+++ b/sample/perf/index.html
@@ -2,6 +2,8 @@
 <script type='module'>
   import Replicache, { REPMWASMInvoker, REPMHTTPInvoker } from './node_modules/replicache/out/mod.js';
 
+  const value = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+
   window.httpInvoker = new REPMHTTPInvoker('http://localhost:7002/');
   window.wasmInvoker = new REPMWASMInvoker();
 
@@ -23,7 +25,7 @@
     var set = rep.register('populate', async (tx, args) => {
       var promises = [];
       for (var i = 0; i < numKeys; i++) {
-        var p = tx.put(`key${i}`, 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
+        var p = tx.put(`key${i}`, value);
         if (parallel) {
           promises.push(p);
         } else {
@@ -39,14 +41,18 @@
 
   async function benchmark_populate(invoker, bench, opts) {
     var rep = await makeRep(invoker);
+    const valSize = value.length;
     bench.reset();
-    bench.setName(`populate 1024x${opts.numKeys} (${opts.parallel ? 'parallel' : 'serial'})`);
+    bench.setName(`populate ${valSize}x${opts.numKeys} (${opts.parallel ? 'parallel' : 'serial'})`);
+    bench.setSize(opts.numKeys * valSize);
     await populate(rep, opts);
   }
 
   async function benchmark_scan(invoker, bench, opts) {
     var rep = await makeRep(invoker);
-    bench.setName(`scan 1024x${opts.numKeys}`);
+    const valSize = value.length;
+    bench.setName(`scan ${valSize}x${opts.numKeys}`);
+    bench.setSize(opts.numKeys * valSize);
     await populate(rep, opts);
     bench.reset();
     await rep.query(async (tx) => {
@@ -57,11 +63,12 @@
     });
   }
 
-  async function benchmark(opts, fn) {
-    const n = opts.n || 3;
+  async function benchmark(fn) {
+    const n = 3;
     const times = [];
     let sum = 0;
     let name = String(fn);
+    let size = null;
     for (var i = 0; i < n; i++) {
       let t0 = Date.now();
       await fn({
@@ -69,6 +76,7 @@
           t0 = Date.now();
         },
         setName: (n) => name = n,
+        setSize: (s) => size = s,
       });
       const dur = Date.now() - t0;
       times.push(dur);
@@ -81,20 +89,17 @@
       name,
       `Median: ${median}`,
     ];
-    if (opts.size) {
-      out.push('Throughput: ' + humanSize(opts.size / median * 1000) + '/s');
+    if (size) {
+      out.push('Throughput: ' + humanSize(size / median * 1000) + '/s');
     }
     log(...out);
   }
 
   window.main = async function (invoker) {
     log(`Running benchmarks with ${invoker.constructor.name} please wait...`)
-    await benchmark({ size: 1024 * 1000 },
-      (bench) => benchmark_populate(invoker, bench, { numKeys: 1000, parallel: false }));
-    await benchmark({ size: 1024 * 1000 },
-      (bench) => benchmark_populate(invoker, bench, { numKeys: 1000, parallel: true }));
-    await benchmark({ size: 1024 * 1000 },
-      (bench) => benchmark_scan(invoker, bench, { numKeys: 1000 }));
+    await benchmark((bench) => benchmark_populate(invoker, bench, { numKeys: 1000, parallel: false }));
+    await benchmark((bench) => benchmark_populate(invoker, bench, { numKeys: 1000, parallel: true }));
+    await benchmark((bench) => benchmark_scan(invoker, bench, { numKeys: 1000 }));
     log('Done!');
   }
 

--- a/sample/perf/index.html
+++ b/sample/perf/index.html
@@ -56,10 +56,12 @@
     await populate(rep, opts);
     bench.reset();
     await rep.query(async (tx) => {
-      let i = 0;
+      var count = 0;
       for await (const value of tx.scan()) {
-        i++;
+        // use the value to be confident we're not optimizing away.
+        count += value.length;
       }
+      console.log(count);
     });
   }
 

--- a/src/scan-iterator.ts
+++ b/src/scan-iterator.ts
@@ -4,14 +4,15 @@ import type {Invoke} from './repm-invoker.js';
 import type {JSONValue} from './json.js';
 import {throwIfClosed} from './transactions.js';
 
-export let scanPageSize = 100;
+const defaultScanSize = 500;
+export let scanPageSize = defaultScanSize;
 
 export function setScanPageSizeForTesting(n: number): void {
   scanPageSize = n;
 }
 
 export function restoreScanPageSizeForTesting(): void {
-  scanPageSize = 100;
+  scanPageSize = defaultScanSize;
 }
 
 interface IdCloser {


### PR DESCRIPTION
We should wire this up to run continuously on bots. It's super super easy to regress things accidentally (as this log shows).