### PR TITLE
Only run tests on chromium

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.2.0",
   "repository": "github:rocicorp/replicache-sdk-js",
   "scripts": {
-    "test": "web-test-runner src/replicache.test.ts --playwright --browsers chromium firefox",
-    "test:watch": "web-test-runner src/replicache.test.ts --playwright --browsers chromium firefox --watch",
+    "test": "web-test-runner src/replicache.test.ts --playwright --browsers chromium",
+    "test:watch": "web-test-runner src/replicache.test.ts --playwright --browsers chromium firefox webkit --watch",
     "format": "prettier --write '{src,sample}/**/*.{js,jsx,json,ts,tsx,html,css,md}' '*.{js,jsx,json,ts,tsx,html,css,md}'",
     "check-format": "prettier --check '{src,sample}/**/*.{js,jsx,json,ts,tsx,html,css,md}' '*.{js,jsx,json,ts,tsx,html,css,md}'",
     "lint": "eslint --ext .ts src/",


### PR DESCRIPTION
This is mostly to prevent race conditions until we have mocked all the
server requests.