### PR TITLE
Make the key in scan over index a tuple

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -7,7 +7,6 @@ export type {Mutator} from './replicache.js';
 export type {ScanKey} from './scan-key.js';
 /** @deprecated Use ScanKey instead */
 export type {ScanKey as ScanId} from './scan-key.js';
-export type {ScanBound} from './scan-bound.js';
 export type {REPMInvoke, Invoker} from './repm-invoker.js';
 export type {ReadTransaction, WriteTransaction} from './transactions.js';
 export type {ScanResult} from './scan-iterator.js';

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -4,9 +4,11 @@ export {TransactionClosedError} from './transaction-closed-error.js';
 export {REPMWasmInvoker} from './repm-invoker.js';
 
 export type {Mutator} from './replicache.js';
+/** @deprecated ScanKey is no longer used */
 export type {ScanKey} from './scan-key.js';
-/** @deprecated Use ScanKey instead */
+/** @deprecated ScanId is no longer used */
 export type {ScanKey as ScanId} from './scan-key.js';
 export type {REPMInvoke, Invoker} from './repm-invoker.js';
 export type {ReadTransaction, WriteTransaction} from './transactions.js';
 export type {ScanResult} from './scan-iterator.js';
+export type {KeyTypeForScanOptions, ScanOptions} from './scan-options.js';

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1,5 +1,5 @@
 import {ReplicacheTest, httpStatusUnauthorized} from './replicache.js';
-import Replicache, {ScanBound, TransactionClosedError} from './mod.js';
+import Replicache, {TransactionClosedError} from './mod.js';
 
 import type {ReadTransaction, WriteTransaction} from './mod.js';
 import type {JSONValue} from './json.js';
@@ -13,6 +13,7 @@ import type {SinonSpy} from 'sinon';
 // @ts-expect-error
 import fetchMock from 'fetch-mock/esm/client.js';
 import type {Invoke} from './repm-invoker.js';
+import type {ScanOptions} from './scan-options.js';
 
 const {fail} = assert;
 
@@ -163,7 +164,7 @@ test('scan', async () => {
   });
 
   async function testScanResult<K, V>(
-    options: {prefix?: string; start?: ScanBound; limit?: number} | undefined,
+    options: ScanOptions | undefined,
     entries: [K, V][],
   ) {
     if (!rep) {
@@ -226,7 +227,8 @@ test('scan', async () => {
 
   await testScanResult(
     {
-      start: {key: {value: 'b/1', exclusive: false}},
+      startKey: 'b/1',
+      startKeyExclusive: false,
     },
     [
       ['b/1', 6],
@@ -237,7 +239,7 @@ test('scan', async () => {
 
   await testScanResult(
     {
-      start: {key: {value: 'b/1'}},
+      startKey: 'b/1',
     },
     [
       ['b/1', 6],
@@ -248,20 +250,10 @@ test('scan', async () => {
 
   await testScanResult(
     {
-      start: {key: {value: 'b/1', exclusive: true}},
+      startKey: 'b/1',
+      startKeyExclusive: true,
     },
     [
-      ['b/2', 7],
-      ['c/0', 8],
-    ],
-  );
-
-  await testScanResult(
-    {
-      start: {index: 6},
-    },
-    [
-      ['b/1', 6],
       ['b/2', 7],
       ['c/0', 8],
     ],

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -846,7 +846,7 @@ test('index', async () => {
     tx.createIndex({name: 'aIndex', jsonPointer: '/a'}),
   )(null);
 
- await testScanResult({indexName: 'aIndex'}, [
+  await testScanResult({indexName: 'aIndex'}, [
     [['0', 'a/0'], {a: '0'}],
     [['1', 'a/1'], {a: '1'}],
     [['2', 'a/2'], {a: '2'}],

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -1,5 +1,5 @@
 import type {JSONValue, ToJSON} from './json.js';
-import type {ScanOptions} from './scan-options.js';
+import type {KeyTypeForScanOptions, ScanOptions} from './scan-options.js';
 import {
   Invoker,
   Invoke,
@@ -223,16 +223,14 @@ export default class Replicache implements ReadTransaction {
    * Gets many values from the database. This returns a `Result` which
    * implements `AsyncIterable`. It also has methods to iterate over the `keys`
    * and `entries`.
-   * */
-  scan({
-    prefix = '',
-    startKey,
-    startKeyExclusive,
-    limit,
-    indexName,
-  }: ScanOptions = {}): ScanResult {
+   */
+  scan<O extends ScanOptions, K extends KeyTypeForScanOptions<O>>(
+    options?: O,
+  ): ScanResult<K> {
+    const {prefix = '', startKey, startKeyExclusive, limit, indexName} =
+      options || {};
     let tx: ReadTransactionImpl;
-    return new ScanResult(
+    return new ScanResult<K>(
       prefix,
       startKey,
       startKeyExclusive,
@@ -252,9 +250,11 @@ export default class Replicache implements ReadTransaction {
   }
 
   /**
-   * Convenience form of scan() which returns all the results as an array.
+   * Convenience form of scan() which returns all the entries as an array.
    */
-  async scanAll(options: ScanOptions = {}): Promise<[string, JSONValue][]> {
+  async scanAll<O extends ScanOptions, K extends KeyTypeForScanOptions<O>>(
+    options?: O,
+  ): Promise<[K, JSONValue][]> {
     const tx = new ReadTransactionImpl(this._invoke);
     try {
       await tx.open({});

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -224,11 +224,18 @@ export default class Replicache implements ReadTransaction {
    * implements `AsyncIterable`. It also has methods to iterate over the `keys`
    * and `entries`.
    * */
-  scan({prefix = '', start, limit, indexName}: ScanOptions = {}): ScanResult {
+  scan({
+    prefix = '',
+    startKey,
+    startKeyExclusive,
+    limit,
+    indexName,
+  }: ScanOptions = {}): ScanResult {
     let tx: ReadTransactionImpl;
     return new ScanResult(
       prefix,
-      start,
+      startKey,
+      startKeyExclusive,
       limit,
       indexName,
       this._invoke,

--- a/src/repm-invoker.ts
+++ b/src/repm-invoker.ts
@@ -74,18 +74,15 @@ type TransactionRequest = {
   transactionId: number;
 };
 
-interface ScanItemResponse {
-  readonly key: string;
-  readonly value: string;
-}
-
 export type ScanRequest = TransactionRequest & {
   opts?: ScanOptionsRpc;
-  receiver: (k: string, v: Uint8Array) => void;
+  receiver: (
+    primaryKey: string,
+    secondaryKey: string | null,
+    value: Uint8Array,
+  ) => void;
 };
-export type ScanResponse = {
-  items: ScanItemResponse[];
-};
+export type ScanResponse = unknown;
 
 type PutRequest = TransactionRequest & {
   key: string;

--- a/src/repm-invoker.ts
+++ b/src/repm-invoker.ts
@@ -1,5 +1,5 @@
 import type {JSONValue, ToJSON} from './json.js';
-import type {ScanOptions} from './scan-options.js';
+import type {ScanOptionsRpc} from './scan-options.js';
 import init, {dispatch} from './wasm/release/replicache_client.js';
 import type {InitInput, InitOutput} from './wasm/release/replicache_client.js';
 
@@ -79,11 +79,10 @@ interface ScanItemResponse {
   readonly value: string;
 }
 
-export type ScanRequest = TransactionRequest &
-  ScanOptions & {
-    opts?: ScanOptions;
-    receiver: (k: string, v: Uint8Array) => void;
-  };
+export type ScanRequest = TransactionRequest & {
+  opts?: ScanOptionsRpc;
+  receiver: (k: string, v: Uint8Array) => void;
+};
 export type ScanResponse = {
   items: ScanItemResponse[];
 };

--- a/src/scan-bound.ts
+++ b/src/scan-bound.ts
@@ -1,6 +1,0 @@
-import type {ScanKey} from './scan-key.js';
-
-export interface ScanBound {
-  readonly key?: ScanKey;
-  readonly index?: number;
-}

--- a/src/scan-item.ts
+++ b/src/scan-item.ts
@@ -1,6 +1,7 @@
 import type {JSONValue} from './json.js';
 
-export interface ScanItem {
-  readonly key: string;
-  readonly value: JSONValue;
-}
+export type ScanItem = {
+  primaryKey: string;
+  secondaryKey: string | null;
+  value: JSONValue;
+};

--- a/src/scan-key.ts
+++ b/src/scan-key.ts
@@ -1,3 +1,4 @@
+/** @deprecated ScanKey is no longer used */
 export interface ScanKey {
   readonly value: string;
   readonly exclusive?: boolean;

--- a/src/scan-options.ts
+++ b/src/scan-options.ts
@@ -6,6 +6,15 @@ export interface ScanOptions {
   indexName?: string;
 }
 
+/**
+ * Ifthe options contains an indexName then the key type is a tuple of secondaryKey, primaryKey.
+ */
+export type KeyTypeForScanOptions<O extends ScanOptions> = O extends {
+  indexName: string;
+}
+  ? [secondary: string, primary: string]
+  : string;
+
 export interface ScanOptionsRpc {
   prefix?: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/scan-options.ts
+++ b/src/scan-options.ts
@@ -1,8 +1,17 @@
-import type {ScanBound} from './scan-bound.js';
-
 export interface ScanOptions {
   prefix?: string;
-  start?: ScanBound;
+  startKey?: string;
+  startKeyExclusive?: boolean;
+  limit?: number;
+  indexName?: string;
+}
+
+export interface ScanOptionsRpc {
+  prefix?: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  start_key?: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  start_key_exclusive?: boolean;
   limit?: number;
   indexName?: string;
 }

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -32,7 +32,13 @@ export interface ReadTransaction {
    * It the `ScanResult` is used after the `ReadTransaction` has been closed it
    * will throw a {@link TransactionClosedError}.
    */
-  scan({prefix, start, limit, indexName}?: ScanOptions): ScanResult;
+  scan({
+    prefix,
+    startKey,
+    startKeyExclusive,
+    limit,
+    indexName,
+  }?: ScanOptions): ScanResult;
 
   /**
    * Convenience for scan() that reads all results into an array.
@@ -70,10 +76,17 @@ export class ReadTransactionImpl implements ReadTransaction {
     return result['has'];
   }
 
-  scan({prefix = '', start, limit, indexName}: ScanOptions = {}): ScanResult {
+  scan({
+    prefix = '',
+    startKey,
+    startKeyExclusive,
+    limit,
+    indexName,
+  }: ScanOptions = {}): ScanResult {
     return new ScanResult(
       prefix,
-      start,
+      startKey,
+      startKeyExclusive,
       limit,
       indexName,
       this._invoke,

--- a/tool/get-deps.sh
+++ b/tool/get-deps.sh
@@ -2,7 +2,7 @@
 ORIG=`pwd`
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT=$DIR/../
-REPC_VERSION='v0.12.0'
+REPC_VERSION='v0.13.0'
 
 (
   cd $ROOT


### PR DESCRIPTION
When you do `scan` over an index by passing `indexName` the key in the
`keys` iterator and the `entries` iterator is now a tuple of
`[secondary: string, primary: string]`.

`scanAll` is updated too.

JS side of rocicorp/repc@73a2dfc