### PR TITLE
Allows Next.js using Webpack 5 to work

### DIFF
--- a/src/repm-invoker.ts
+++ b/src/repm-invoker.ts
@@ -41,6 +41,15 @@ let wasmModuleOutput: Promise<InitOutput> | undefined;
 export class REPMWasmInvoker {
   constructor(wasmModuleOrPath?: InitInput) {
     if (!wasmModuleOutput) {
+      // Hack around Webpack invalid support for import.meta.url and wasm
+      // loaders. We use the new URL pattern to tell Webpack to use a runtime
+      // URL and not a compile time file: URL.
+      if (!wasmModuleOrPath) {
+        wasmModuleOrPath = new URL(
+          './wasm/release/replicache_client_bg.wasm',
+          import.meta.url,
+        );
+      }
       wasmModuleOutput = init(wasmModuleOrPath);
     }
   }


### PR DESCRIPTION
There are a bunch of Webpack/Next.js issues to work around:

- `import.meta.url` generates `file:` URL. Using the `new URL` pattern
  tells Webpack to do runtime URLs.
- `experimental.asyncWebAssembly` causes Webpack to parse the wasm file
  and validate imports which it doesn't do correctly. Instead you need
  to use `type: "asset/resource"`.
  - But this puts the wasm file in `_next` which cause 404. We need to
    tell webpack to put the file in `static/` too

Towards #151