### PR TITLE
Name the Replicache instance.

### DIFF
--- a/sample/lit-todo/main.js
+++ b/sample/lit-todo/main.js
@@ -15,6 +15,8 @@ import {generateKeyBetween} from 'fractional-indexing';
 const key = id => `/todo/${id}`;
 
 let rep = new Replicache({
+  name: 'todo',
+
   // URL of the diff server to use. The diff server periodically fetches
   // the 'client view' from your service and returns any delta. You can
   // use our hosted diff server (as here) or a local diff server, which


### PR DESCRIPTION
This is an easy way to start fresh on the client. Because backend is nuking data on every schema change, it makes clients unable to sync because they are at a sequence number far ahead of server.

Really what we need to do is put a version number in the protocol and nuke local state when it changes but ... another day.