### PR TITLE
Fix extraneous pull requests

### DIFF
--- a/sample/lit-todo/main.js
+++ b/sample/lit-todo/main.js
@@ -244,7 +244,7 @@ function initPusher() {
   }
   pusher = new Pusher('8084fa6056631d43897d', {
     cluster: 'us3',
-  })
-    .subscribe(`u-${dataLayerAuth}`)
-    .bind('poke', () => rep.sync());
+  });
+  const sub = pusher.subscribe(`u-${dataLayerAuth}`);
+  sub.bind('poke', () => rep.sync());
 }


### PR DESCRIPTION
We were seeing many extra pull requests. This was caused by receiving many notifications through pusherjs. That in turn turned out to be because for some reason disconnect() doesn't work on pusherjs when called on the subscription.

For some reason it exists on both but needs to be called on the connection.