### PR TITLE
Use a ReadableStream internally for scan

### DIFF
--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -739,6 +739,7 @@ export class ReplicacheTest extends Replicache {
       diffServerURL,
       name,
       syncInterval: null,
+      pushDelay: 0,
     });
     await rep._opened;
     return rep;


### PR DESCRIPTION
This allows the receiver callback to scan to deliver its result without
waiting for all the items to load.

This also simplifies the scan iterator by using an async generator.

Fixes #230