### PR TITLE
Call subscribe onData when query retval changes

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -4,9 +4,82 @@ export type JSONValue =
   | boolean
   | number
   | Array<JSONValue>
-  // undefined are filtered out in JSON.stringify so OK to allow.
-  | {[key: string]: JSONValue | undefined};
+  | JSONObject;
 
-export type ToJSON = {
-  toJSON: () => JSONValue;
-};
+type JSONObject = {[key: string]: JSONValue};
+
+/**
+ * Checks deep equality of two JSON value with (almost) same semantics as
+ * `JSON.stringify`. The only difference is that with `JSON.stringify` the
+ * ordering of the properties in an object/map/dictionary matters. In
+ * [[deepEqual]] the following two values are consider equal, even though the
+ * strings JSON.stringify would produce is different:
+ *
+ * ```js
+ * assert(deepEqual(t({a: 1, b: 2}, {b: 2, a: 1}))
+ * ```
+ */
+export function deepEqual(
+  a: JSONValue | undefined,
+  b: JSONValue | undefined,
+): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (typeof a !== typeof b) {
+    return false;
+  }
+
+  switch (typeof a) {
+    case 'boolean':
+    case 'number':
+    case 'string':
+      return false;
+  }
+
+  // a cannot be undefined here because either a and b are undefined or their
+  // types are different.
+  //eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
+  a = a!;
+
+  // 'object'
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b)) {
+      return false;
+    }
+    if (a.length !== b.length) {
+      return false;
+    }
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (a === null || b === null) {
+    return false;
+  }
+
+  if (Array.isArray(b)) {
+    return false;
+  }
+
+  // We know b is an object here but type inference is not smart enough.
+  b = b as JSONObject;
+
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+
+  for (const key of aKeys) {
+    if (!deepEqual(a[key], b[key])) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/repm-invoker.ts
+++ b/src/repm-invoker.ts
@@ -1,4 +1,4 @@
-import type {JSONValue, ToJSON} from './json.js';
+import type {JSONValue} from './json.js';
 import type {ScanOptionsRPC} from './scan-options.js';
 import init, {dispatch} from './wasm/release/replicache_client.js';
 import type {InitInput, InitOutput} from './wasm/release/replicache_client.js';
@@ -15,7 +15,7 @@ export interface Invoke {
   <RPC extends keyof InvokeMap>(rpc: RPC, args: InvokeMap[RPC][0]): Promise<
     InvokeMap[RPC][1]
   >;
-  (rpc: string, args?: JSONValue | ToJSON): Promise<JSONValue>;
+  (rpc: string, args?: JSONValue): Promise<JSONValue>;
 }
 
 export interface REPMInvoke {
@@ -27,7 +27,7 @@ export interface REPMInvoke {
     rpc: RPC,
     args: InvokeMap[RPC][0],
   ): Promise<InvokeMap[RPC][1]>;
-  (dbName: string, rpc: string, args?: JSONValue | ToJSON): Promise<JSONValue>;
+  (dbName: string, rpc: string, args?: JSONValue): Promise<JSONValue>;
 }
 
 let wasmModuleOutput: Promise<InitOutput> | undefined;
@@ -54,7 +54,7 @@ export class REPMWasmInvoker {
   invoke: REPMInvoke = async (
     dbName: string,
     rpc: string,
-    args: JSONValue | ToJSON = {},
+    args: JSONValue = {},
   ): Promise<JSONValue> => {
     await wasmModuleOutput;
     return await dispatch(dbName, rpc, args);

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -1,4 +1,4 @@
-import type {JSONValue, ToJSON} from './json.js';
+import type {JSONValue} from './json.js';
 import type {
   Invoke,
   OpenTransactionRequest,
@@ -133,7 +133,7 @@ export interface WriteTransaction extends ReadTransaction {
    * Sets a single value in the database. The `value` will be encoded using
    * `JSON.stringify`.
    */
-  put(key: string, value: JSONValue | ToJSON): Promise<void>;
+  put(key: string, value: JSONValue): Promise<void>;
 
   /**
    * Removes a key and its value from the database. Returns true if there was a
@@ -145,7 +145,7 @@ export interface WriteTransaction extends ReadTransaction {
 export class WriteTransactionImpl
   extends ReadTransactionImpl
   implements WriteTransaction {
-  async put(key: string, value: JSONValue | ToJSON): Promise<void> {
+  async put(key: string, value: JSONValue): Promise<void> {
     throwIfClosed(this);
     await this._invoke('put', {
       transactionId: this.id,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,9 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "outDir": "out",
-    "allowJs": true
+    "allowJs": true,
+    // esnext for Object.fromEntries
+    "lib": ["dom", "esnext"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist/**/*", "build/**/*"]


### PR DESCRIPTION
For `subscribe`, we now only call `onData` if the return value of the
`body` function changes compared to last time.

This requires that we store the last return value to be able to compare
with that.

We consider the values equal if they behave like `JSON.stringify(a) ===
JSON.stringify(b)` except for the ordering of the property keys.

*BREAKING CHANGE*

This is a breaking API change because subscribe now has a slightly more
restricted type which can lead to new TypeScript type errors.