### PR TITLE
Update redo sample to 4.0.1

### DIFF
--- a/sample/redo/package-lock.json
+++ b/sample/redo/package-lock.json
@@ -11096,9 +11096,9 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "replicache": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/replicache/-/replicache-4.0.0.tgz",
-      "integrity": "sha512-vMhieq1I0AH1KWfiSi6l0WYqIXJcozQWK6CCauJVVawgYn7w8349PpBHojqXr59f53eoWDeVLh3CjiYf+x9CIQ=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/replicache/-/replicache-4.0.1.tgz",
+      "integrity": "sha512-tHiheOUXE7QRfnnMnurdF/VcNiBQ2xZrRt5waxWBUF/PEpU8HcDw8HzoszcvEnSNgDQpsh4ZNL8MyJ5ZNoYfHw=="
     },
     "request": {
       "version": "2.88.2",

--- a/sample/redo/package.json
+++ b/sample/redo/package.json
@@ -56,7 +56,7 @@
     "react-beautiful-dnd": "^13.0.0",
     "react-dev-utils": "^10.2.1",
     "react-dom": "^16.13.1",
-    "replicache": "^4.0.0",
+    "replicache": "^4.0.1",
     "resolve": "1.15.0",
     "resolve-url-loader": "3.1.1",
     "sass-loader": "8.0.2",

--- a/sample/redo/src/App.tsx
+++ b/sample/redo/src/App.tsx
@@ -197,10 +197,8 @@ function registerMutations(rep: Replicache) {
 
   const updateTodo = rep.register(
     'updateTodo',
-    async (tx: WriteTransaction, args: JSONValue) => {
-      // TODO(arv): Fix me. This should really be Partial<Todo> & {id: number} but we cannot pass in optional fields any more :'(
-      const a = args as Partial<Todo> & {id: number};
-      const {id} = a;
+    async (tx: WriteTransaction, args: Partial<Todo> & {id: number}) => {
+      const {id} = args;
       const todo = await read(tx, id);
       if (!todo) {
         console.info(
@@ -209,9 +207,9 @@ function registerMutations(rep: Replicache) {
         );
         return;
       }
-      todo.text = a.text ?? todo.text;
-      todo.complete = a.complete ?? todo.complete;
-      todo.order = a.order ?? todo.order;
+      todo.text = args.text ?? todo.text;
+      todo.complete = args.complete ?? todo.complete;
+      todo.order = args.order ?? todo.order;
       await write(tx, todo);
     },
   );


### PR DESCRIPTION
This is to allow Partial JSON objects in mutator args again.