### PR TITLE
Prevent multiple queued up syncs

### DIFF
--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -696,15 +696,21 @@ testWithBothStores('sync', async () => {
   expect(createCount).to.equal(3);
 });
 
-test('sync2', async () => {
+testWithBothStores('sync debouncing', async () => {
   rep = await replicacheForTesting('sync2');
 
   const spy = spyInvoke(rep);
 
   const s1 = rep.sync();
   const s2 = rep.sync();
+  const s3 = rep.sync();
+  const s4 = rep.sync();
   await s1;
   await s2;
+  await s3;
+  await s4;
+
+  await sleep(10);
 
   const calls = spy.args;
   const syncCalls = calls.filter(([rpc]) => rpc === 'beginSync').length;
@@ -1351,3 +1357,8 @@ testWithBothStores('isEmpty', async () => {
 
   await t(false);
 });
+function sleep(ms: number): Promise<void> {
+  return new Promise(res => {
+    setTimeout(() => res(), ms);
+  });
+}

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -538,10 +538,9 @@ export default class Replicache implements ReadTransaction {
     // Replay.
     console.group('Replaying');
     for (const mutation of replayMutations) {
-      const {original} = mutation;
       syncHead = await this._replay(
         syncHead,
-        original,
+        mutation.original,
         mutation.name,
         JSON.parse(mutation.args),
       );
@@ -595,7 +594,9 @@ export default class Replicache implements ReadTransaction {
 
     if (this._syncPromise !== null) {
       await this._syncPromise;
-      await this.sync();
+      // Call schedule instead of sync to debounce/dedupe multiple calls.
+      this._clearTimer();
+      this._scheduleSync(1);
       return;
     }
 


### PR DESCRIPTION
Multiple calls to sync during an in progress sync queued up all those
syncs to later be called sequentially.

Fixes #277