### PR TITLE
Make sure we only send one push at the time

### DIFF
--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -997,7 +997,7 @@ testWithBothStores('sync debouncing', async () => {
   await sleep(10);
 
   const calls = spy.args;
-  const syncCalls = calls.filter(([rpc]) => rpc === 'beginTryPull').length;
+  const syncCalls = calls.filter(([rpc]) => rpc === 'tryPush').length;
   expect(syncCalls).to.equal(2);
 });
 
@@ -1727,7 +1727,7 @@ testWithBothStores('push timing', async () => {
 
   expect(tryPushCalls()).to.eq(0);
 
-  await sleep(pushDelay * 2);
+  await sleep(pushDelay * 5);
 
   expect(tryPushCalls()).to.eq(1);
   spy.resetHistory();

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -850,7 +850,7 @@ testWithBothStores('push delay', async () => {
 
   expect(fetchMock.calls()).to.have.length(0);
 
-  await sleep(5);
+  await sleep(25);
 
   expect(fetchMock.calls()).to.have.length(1);
 });
@@ -1727,7 +1727,7 @@ testWithBothStores('push timing', async () => {
 
   expect(tryPushCalls()).to.eq(0);
 
-  await sleep(pushDelay * 5);
+  await sleep(pushDelay * 10);
 
   expect(tryPushCalls()).to.eq(1);
   spy.resetHistory();

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1662,7 +1662,7 @@ testWithBothStores('onSync', async () => {
   fetchMock.postOnce(pushURL, {});
   onSync.resetHistory();
   await add({a: 'a'});
-  await sleep(5);
+  await sleep(25);
   expect(onSync.callCount).to.eq(2);
   expect(onSync.getCall(0).args[0]).to.be.true;
   expect(onSync.getCall(1).args[0]).to.be.false;

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1696,7 +1696,7 @@ testWithBothStores('onSync', async () => {
   expect(onSync.callCount).to.eq(0);
 });
 
-test('push timing', async () => {
+testWithBothStores('push timing', async () => {
   const pushURL = 'https://push.com/push';
   const pushDelay = 5;
 
@@ -1781,6 +1781,12 @@ testWithBothStores('push and pull concurrently', async () => {
   const pushP2 = rep.push();
   const pushP3 = rep.push();
 
+  const resolveOrder: string[] = [];
+  pushP1.then(() => resolveOrder.push('pushP1'));
+  pullP1.then(() => resolveOrder.push('pullP1'));
+  pushP2.then(() => resolveOrder.push('pushP2'));
+  pushP3.then(() => resolveOrder.push('pushP3'));
+
   const rpcs = () => spy.args.map(a => a[0]);
 
   // Only one push at a time but we want push and pull to be concurrent.
@@ -1806,8 +1812,8 @@ testWithBothStores('push and pull concurrently', async () => {
 
   expect(reqs).to.eql([pullURL, pushURL, pushURL]);
   expect(rpcs()).to.eql(['tryPush', 'beginTryPull', 'tryPush']);
-  // await pushP2;
 
-  // expect(reqs()).to.eql([pushURL, pullURL, pushURL]);
-  // expect(rpcs()).to.eql(['tryPush', 'beginTryPull', 'tryPush']);
+  // pull resolves first because it is not waiting for any promise in its
+  // fetchMock.
+  expect(resolveOrder).to.eql(['pullP1', 'pushP1', 'pushP2', 'pushP3']);
 });

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,0 +1,10 @@
+export function resolver<R = void>(): {
+  promise: Promise<R>;
+  resolve: (res: R) => void;
+} {
+  let resolve!: (res: R) => void;
+  const promise = new Promise<R>(res => {
+    resolve = res;
+  });
+  return {promise, resolve};
+}


### PR DESCRIPTION
We allow push and pulls to be sent at the same time but if there are
multiple calls to push/pull then the first pull/push needs to finish
before we send anoter pull/push.

If there are multiple pull/push calls during an existing pull/push these
gets collapsed into a single pull/push.

Towards #294